### PR TITLE
Fix file and class names for NoRandomGeneratorTest

### DIFF
--- a/Tests/RandomGenerator/NoRandomGeneratorTest.php
+++ b/Tests/RandomGenerator/NoRandomGeneratorTest.php
@@ -4,7 +4,7 @@ namespace Hackzilla\PasswordGenerator\Tests\RandomGenerator;
 
 use Hackzilla\PasswordGenerator\RandomGenerator\NoRandomGenerator;
 
-class HybridPasswordGeneratorTest extends \PHPUnit\Framework\TestCase
+class NoRandomGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     private $_object;
 


### PR DESCRIPTION
The latest composer snapshot throws the following error when trying to generate an optimised autoloader:

```
Deprecation Notice: Class Hackzilla\PasswordGenerator\Tests\RandomGenerator\HybridPasswordGeneratorTest located in ./vendor/hackzilla/password-generator/Tests/RandomGenerator/NoPasswordGeneratorTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v1.11+.
```